### PR TITLE
fix: Do not override the command order of a custom group's list_commands()

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+v0.3.4 (15-AUG-2024)
+====================
+* `list_commands order should be honored when generated nested sections for subcommands. <https://github.com/sphinx-contrib/typer/issues/36>`_
+
+
 v0.3.3 (15-JUL-2024)
 ====================
 

--- a/sphinxcontrib/typer/__init__.py
+++ b/sphinxcontrib/typer/__init__.py
@@ -70,23 +70,20 @@ def get_function(function: t.Union[str, t.Callable[..., t.Any]]):
 
 
 def _filter_commands(ctx: click.Context, cmd_filter: t.Optional[t.List[str]] = None):
-    return sorted(
-        [
-            cmd
-            for name, cmd in getattr(
-                ctx.command,
-                "commands",
-                {
-                    name: ctx.command.get_command(ctx, name)
-                    for name in getattr(ctx.command, "list_commands", lambda _: [])(ctx)
-                    or cmd_filter
-                    or []
-                },
-            ).items()
-            if not cmd_filter or name in cmd_filter
-        ],
-        key=lambda item: item.name,
-    )
+    return [
+        cmd
+        for name, cmd in getattr(
+            ctx.command,
+            "commands",
+            {
+                name: ctx.command.get_command(ctx, name)
+                for name in getattr(ctx.command, "list_commands", lambda _: [])(ctx)
+                or cmd_filter
+                or []
+            },
+        ).items()
+        if not cmd_filter or name in cmd_filter
+    ]
 
 
 class RenderTarget(str, Enum):

--- a/sphinxcontrib/typer/__init__.py
+++ b/sphinxcontrib/typer/__init__.py
@@ -54,7 +54,7 @@ __title__ = "SphinxContrib Typer"
 __version__ = ".".join(str(i) for i in VERSION)
 __author__ = "Brian Kohan"
 __license__ = "MIT"
-__copyright__ = "Copyright 2023 Brian Kohan"
+__copyright__ = "Copyright 2023-2024 Brian Kohan"
 
 
 SELENIUM_DEFAULT_WINDOW_WIDTH = 1920
@@ -69,21 +69,8 @@ def get_function(function: t.Union[str, t.Callable[..., t.Any]]):
         return getattr(import_module(".".join(parts[0:-1])), parts[-1])
 
 
-def _filter_commands(ctx: click.Context, cmd_filter: t.Optional[t.List[str]] = None):
-    return [
-        cmd
-        for name, cmd in getattr(
-            ctx.command,
-            "commands",
-            {
-                name: ctx.command.get_command(ctx, name)
-                for name in getattr(ctx.command, "list_commands", lambda _: [])(ctx)
-                or cmd_filter
-                or []
-            },
-        ).items()
-        if not cmd_filter or name in cmd_filter
-    ]
+def _filter_commands(ctx: click.Context, cmd_filter: t.List[str]):
+    return [ctx.command.commands[cmd_name] for cmd_name in cmd_filter]
 
 
 class RenderTarget(str, Enum):

--- a/tests/click/aliases/aliases.py
+++ b/tests/click/aliases/aliases.py
@@ -39,6 +39,9 @@ class AliasedGroup(click.Group):
     file and with a bit of magic.
     """
 
+    def list_commands(self, ctx):
+        return reversed(sorted(super().list_commands(ctx)))
+
     def get_command(self, ctx, cmd_name):
         # Step one: bulitin commands as normal
         rv = click.Group.get_command(self, ctx, cmd_name)

--- a/tests/click/completion/completion.py
+++ b/tests/click/completion/completion.py
@@ -4,7 +4,12 @@ import click
 from click.shell_completion import CompletionItem
 
 
-@click.group()
+class AlphOrderedGroup(click.Group):
+    def list_commands(self, ctx):
+        return sorted(super().list_commands(ctx))
+
+
+@click.group(cls=AlphOrderedGroup)
 def cli():
     pass
 

--- a/tests/click/imagepipe/imagepipe.py
+++ b/tests/click/imagepipe/imagepipe.py
@@ -7,7 +7,12 @@ from PIL import ImageFilter
 import click
 
 
-@click.group(chain=True)
+class AlphOrderedGroup(click.Group):
+    def list_commands(self, ctx):
+        return sorted(super().list_commands(ctx))
+
+
+@click.group(cls=AlphOrderedGroup, chain=True)
 def cli():
     """This script processes a bunch of images through pillow in a unix
     pipe.  One commands feeds into the next.

--- a/tests/click/naval/naval.py
+++ b/tests/click/naval/naval.py
@@ -1,7 +1,12 @@
 import click
 
 
-@click.group()
+class AlphOrderedGroup(click.Group):
+    def list_commands(self, ctx):
+        return sorted(super().list_commands(ctx))
+
+
+@click.group(cls=AlphOrderedGroup)
 @click.version_option()
 def cli():
     """Naval Fate.
@@ -12,7 +17,7 @@ def cli():
     """
 
 
-@cli.group()
+@cli.group(cls=AlphOrderedGroup)
 def ship():
     """Manages ships."""
 

--- a/tests/click/repo/repo.py
+++ b/tests/click/repo/repo.py
@@ -5,6 +5,11 @@ import sys
 import click
 
 
+class AlphOrderedGroup(click.Group):
+    def list_commands(self, ctx):
+        return sorted(super().list_commands(ctx))
+
+
 class Repo:
     def __init__(self, home):
         self.home = home
@@ -23,7 +28,7 @@ class Repo:
 pass_repo = click.make_pass_decorator(Repo)
 
 
-@click.group()
+@click.group(cls=AlphOrderedGroup)
 @click.option(
     "--repo-home",
     envvar="REPO_HOME",

--- a/tests/click/termui/termui.py
+++ b/tests/click/termui/termui.py
@@ -5,7 +5,12 @@ import time
 import click
 
 
-@click.group()
+class AlphOrderedGroup(click.Group):
+    def list_commands(self, ctx):
+        return sorted(super().list_commands(ctx))
+
+
+@click.group(cls=AlphOrderedGroup)
 def cli():
     """This script showcases different terminal UI helpers in Click."""
     pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -476,7 +476,8 @@ def test_click_ex_aliases():
 
     bld_dir, html = build_click_example("aliases", "html")
 
-    subcommands = ["alias", "clone", "commit", "pull", "push", "status"]
+    # we test that list_commands order is honored
+    subcommands = reversed(["alias", "clone", "commit", "pull", "push", "status"])
     helps = [
         get_click_ex_help("aliases"),
         *[get_click_ex_help("aliases", *cmd.split()) for cmd in subcommands],


### PR DESCRIPTION
`list_commands()` is one of ["The most common methods to override"](https://click.palletsprojects.com/en/latest/commands/#custom-groups) in Click. CLIs with many commands typically sort the commands in a logical order (rather than an alphabetical order), to make it easier for users to understand and remember sequence, dependency, etc.

This same behavior is available in Typer. For example, to list commands in the same order in which they are defined and registered:

```python
import typer
import typer.cli

class OrderedGroup(typer.cli.TyperCLIGroup):
    def list_commands(self, ctx: click.Context) -> list[str]:
        self.maybe_add_run(ctx)
        return list(self.commands)


app = typer.Typer(cls=OrderedGroup)
```

sphinxcontrib-typer doesn't respect the established order, and instead re-sorts by name.